### PR TITLE
Append suffix "-loader" to each loaders for webpack2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require('style!css!sass!./materialize-styles!./materialize.config.js');
+require('style-loader!css-loader!sass-loader!./materialize-styles.loader!./materialize.config.js');


### PR DESCRIPTION
Hi. 
I found a minimal bugs when using webpack2. Below is it's error log.
```
ERROR in ./~/materialize-loader/index.js
Module not found: Error: Can't resolve 'style' in '/Users/lycoris/xx/node_modules/materialize-loader'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'style-loader' instead of 'style'.
 @ ./~/materialize-loader/index.js 1:0-87
```

In webpack2, it is not possible omit the "-loader" extension when referencing loaders.   
So, I fixed some points which omitted "-loader".  